### PR TITLE
fix: Update field updatedAt for collections

### DIFF
--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -846,11 +846,13 @@ export function handleCompleteCollection(
 export function handleTransferCreatorship(
   collectionAddress: string,
   event: CollectionV2ABI.CreatorshipTransferredEventArgs,
+  block: Block,
   storedData: PolygonStoredData
 ): void {
   const { collections, items } = storedData;
   const collection = collections.get(collectionAddress);
   const newCreator = event._newCreator;
+  const timestamp = BigInt(block.timestamp / 1000);
   if (collection) {
     collection.creator = newCreator;
     let itemCount = collection.itemsCount;
@@ -865,6 +867,7 @@ export function handleTransferCreatorship(
         );
       }
     }
+    collection.updatedAt = timestamp;
   } else {
     console.log(
       `ERROR: Collection not found in handleTransferCreatorship: ${collectionAddress}`
@@ -875,12 +878,15 @@ export function handleTransferCreatorship(
 export function handleTransferOwnership(
   collectionAddress: string,
   event: CollectionV2ABI.OwnershipTransferredEventArgs,
+  block: Block,
   storedData: PolygonStoredData
 ): void {
   const { collections } = storedData;
   const collection = collections.get(collectionAddress);
+  const timestamp = BigInt(block.timestamp / 1000);
   if (collection) {
     collection.owner = event.newOwner;
+    collection.updatedAt = timestamp;
   } else {
     console.log(
       `ERROR: Collection not found in handleTransferOwnership: ${collectionAddress}`

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -855,6 +855,7 @@ export function handleTransferCreatorship(
   const timestamp = BigInt(block.timestamp / 1000);
   if (collection) {
     collection.creator = newCreator;
+    collection.updatedAt = timestamp;
     let itemCount = collection.itemsCount;
     for (let i = 0; i < itemCount; i++) {
       let itemId = getItemId(collection.id, i.toString());
@@ -868,7 +869,6 @@ export function handleTransferCreatorship(
         );
       }
     }
-    collection.updatedAt = timestamp;
   } else {
     console.log(
       `ERROR: Collection not found in handleTransferCreatorship: ${collectionAddress}`

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -861,6 +861,7 @@ export function handleTransferCreatorship(
       const item = items.get(itemId);
       if (item) {
         item.creator = newCreator;
+        item.updatedAt = timestamp;
       } else {
         console.log(
           `ERROR: Item not found in handleTransferCreatorship: ${itemId}`

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -803,6 +803,7 @@ processor.run(
           handleTransferCreatorship(
             log.address,
             event as CollectionV2ABI.CreatorshipTransferredEventArgs,
+            block.header,
             storedData
           );
           break;
@@ -810,6 +811,7 @@ processor.run(
           handleTransferOwnership(
             log.address,
             event as CollectionV2ABI.OwnershipTransferredEventArgs,
+            block.header,
             storedData
           );
           break;


### PR DESCRIPTION
This PR updates the collections updatedAt field when events transferCreatorship or transferOwnership are detected in the blockchain.